### PR TITLE
 replace stylelint-rule-tester with stylelint-test-rule-tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-declaration-use-variable",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A stylelint custom rule to check the use of scss variable on declaration.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "homepage": "https://github.com/sh-waqar/stylelint-declaration-use-variable",
   "devDependencies": {
     "stylelint-test-rule-tape": "^0.2.0",
-    "tape": "^4.2.2"
+    "tape": "^4.9.0"
   },
   "dependencies": {
-    "stylelint": "^6.8.0"
+    "stylelint": "^9.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/sh-waqar/stylelint-declaration-use-variable",
   "devDependencies": {
+    "stylelint-test-rule-tape": "^0.2.0",
     "tape": "^4.2.2"
   },
   "dependencies": {
-    "stylelint": "^6.8.0",
-    "stylelint-rule-tester": "^0.6.2"
+    "stylelint": "^6.8.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,41 +1,93 @@
-var ruleTester = require('stylelint-rule-tester');
+var ruleTester = require('stylelint-test-rule-tape');
 var declarationUseVariable = require('..');
 
 var messages = declarationUseVariable.messages;
-var testRule = ruleTester(declarationUseVariable.rule, declarationUseVariable.ruleName);
 
 // Test for excluding non-matching properties
-testRule('/color/', function(tr) {
-    tr.ok('.foo { color: $blue; }');
-    tr.ok('.foo { z-index: 22; }');
-    tr.ok('$color-white: #fff; \n.manage-link {\npadding: 0;\ntext-align: center;\nbackground-color: $abc;\nz-index: $foo;\na {\ncolor: $abc;\n&:hover {\ncolor: $red;\n}\n}\n}');
-    tr.notOk('.foo { background-color: #fff; }', messages.expectedPresent('background-color', '$color-white'));
-    tr.notOk('.foo { color: #fcfcf; }', messages.expected('color'));
+ruleTester(declarationUseVariable.rule, {
+  ruleName: declarationUseVariable.ruleName,
+  config: "/color/",
+
+  accept: [
+    {code: '.foo { color: $blue; }'},
+    {code: '.foo { z-index: 22; }'},
+    {code: '$color-white: #fff; \n.manage-link {\npadding: 0;\ntext-align: center;\nbackground-color: $abc;\nz-index: $foo;\na {\ncolor: $abc;\n&:hover {\ncolor: $red;\n}\n}\n}'}
+  ],
+
+  reject: [
+    {
+      code: '.foo { background-color: #fff; }',
+      message: messages.expectedPresent('background-color', '$color-white')
+    },
+    {
+      code: '.foo { color: #fcfcf; }',
+      message: messages.expected('color')
+    }
+  ]
 });
 
 // Test for z-index variables
-testRule('z-index', function(tr) {
-    tr.ok('.foo { z-index: $4; }');
-    tr.ok('.foo { z-index: map-get($map, $val); }');
-    tr.notOk('.foo { z-index: 22; }', messages.expected('z-index'));
+ruleTester(declarationUseVariable.rule, {
+  ruleName: declarationUseVariable.ruleName,
+  config: "z-index",
+
+  accept: [
+    {code: '.foo { z-index: $4; }'},
+    {code: '.foo { z-index: map-get($map, $val); }'}
+  ],
+
+  reject: [
+    {
+      code: '.foo { z-index: 22; }',
+      message: messages.expected('z-index')
+    }
+  ]
 });
 
 // Test for multiple values in array including regex
-testRule(['/color/', 'font-size', 'z-index'], function(tr) {
-    tr.ok('.foo { color: $blue; }');
-    tr.ok('.foo { z-index: $foo; }');
-    tr.ok('.foo { color: map-get($map, $val); }');
-    tr.ok('.foo { background-color: map-get($map, $val); }');
-    tr.notOk('.foo { color: blue; }', messages.expected('color'));
-    tr.notOk('.foo { z-index: 11; }', messages.expected('z-index'));
+ruleTester(declarationUseVariable.rule, {
+  ruleName: declarationUseVariable.ruleName,
+  config: [['/color/', 'font-size', 'z-index']],
+
+  accept: [
+    {code: '.foo { color: $blue; }'},
+    {code: '.foo { z-index: $foo; }'},
+    {code: '.foo { color: map-get($map, $val); }'},
+    {code: '.foo { background-color: map-get($map, $val); }'}
+  ],
+
+  reject: [
+    {
+      code: '.foo { color: blue; }',
+      message: messages.expected('color')
+    },
+    {
+      code: '.foo { z-index: 11; }',
+      message: messages.expected('z-index')
+    }
+  ]
 });
 
 // Test for less, custom properties and color functions
-testRule(['/color/', 'font-size', 'z-index'], function(tr) {
-    tr.ok('.foo { color: @blue; }');
-    tr.ok('.foo { z-index: --foo; }');
-    tr.ok('.foo { color: var(--var-name); }');
-    tr.ok('.foo { color: color($blue shade(10%)); }');
-    tr.notOk('.foo { color: blue; }', messages.expected('color'));
-    tr.notOk('.foo { z-index: 11; }', messages.expected('z-index'));
+ruleTester(declarationUseVariable.rule, {
+  ruleName: declarationUseVariable.ruleName,
+  config: [['/color/', 'font-size', 'z-index']],
+
+  accept: [
+    {code: '.foo { color: @blue; }'},
+    {code: '.foo { z-index: --foo; }'},
+    {code: '.foo { color: var(--var-name); }'},
+    {code: '.foo { color: color($blue shade(10%)); }'}
+  ],
+
+  reject: [
+    {
+      code: '.foo { color: blue; }',
+      message: messages.expected('color')
+    },
+    {
+      code: '.foo { z-index: 11; }',
+      message: messages.expected('z-index')
+    }
+  ]
 });


### PR DESCRIPTION
Fix #20.

npm warns about deprecation. This fix uses the recommended library and also updates other packages to their latest versions.

@sh-waqar if you could merge this PR and release a new version that would be just nice